### PR TITLE
Update CI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [//]: # (Badges)
 [![codecov](https://codecov.io/gh/coleygroup/pyscreener/branch/master/graph/badge.svg)](https://codecov.io/gh/coleygroup/pyscreener/branch/master)
-![CI](https://github.com/coleygroup/pyscreener/workflows/CI/badge.svg)
+[![CI](https://github.com/coleygroup/pyscreener/actions/workflows/CI.yaml/badge.svg)](https://github.com/coleygroup/pyscreener/actions/workflows/CI.yaml)
 [![Documentation Status](https://readthedocs.org/projects/pyscreener/badge/?version=latest)](https://pyscreener.readthedocs.io/en/latest/?badge=latest)
 [![PyPI version](https://badge.fury.io/py/pyscreener.svg)](https://badge.fury.io/py/pyscreener)
 


### PR DESCRIPTION
This links the CI badge to the actions tab of the repo so it is easy to see the builds.
