### PR TITLE
add examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ To test whether your environment is setup correctly with respect to pathing and 
 where `SCREEN_TYPE` and `METADATA_TEMPLATE` and values as described above
 
 If the checks pass, then your environment is set up correctly.
+
 ## Using pyscreener as a library
 To check if `pyscreener` is set up properly, you can run the following:
 ```python
@@ -144,7 +145,7 @@ The object model of pyscreener relies on four classes:
 
 To perform docking calls inside your python code using `pyscreener`, you must first initialize a `DockingVirtualScreen` object either through the factory `pyscreener.virtual_screen` function or manually initializing one. The following section will show an example of how to perform computational from inside a python interpreter.
 
-### Example
+### Examples
 the following code snippet will dock benzene (SMILES string `"c1ccccc1"`) against the D4 dopamine receptor (PDB ID `5WIU`) using a predefined docking box and Autodock Vina
 
 ```python
@@ -172,6 +173,8 @@ A few notes from the above example:
   supply = ps.LigandSupply(['integration-tests/inputs/ligands.csv'])
   virtual_screen(supply.ligands)
   ```
+
+for more examples, check out the [examples](./examples/) folder!
 
 ## Testing
 

--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -1,0 +1,211 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pyscreener quickstart"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting up a virtual screen\n",
+    "\n",
+    "The object model of `pyscreener` is centered around the `VirtualScreen` object. Abstractly, this object represents a **unfiorm** screening protocol against which 10s to millions of compounds will be screened. Roughly, a virtual screening protocol includes the following information:\n",
+    "1. the target\n",
+    "2. the docking box\n",
+    "3. the screening parameters\n",
+    "\n",
+    "The last of these is the most abstract, as we use this to lump all program-specific arguments together. For example, AutoDock Vina type programs might support only a few arguments like `--exhaustiveness` to control the exhaustiveness of the search process, but DOCK6 includes a variety of parameters to fine tune the search process, like `simplex_tors_step`. Obviously, both programs use some knowledge of the target (1) and the docking box (2), but beyond that, they don't have much in common in terms of how they're run.\n",
+    "\n",
+    "There are a wealth of possble options for how a virtual screen *might* be conducted, but our primary goal with `pyscreener` is to support users who really want to rely on the base docking parameters to quickly filter out possible compound ideas with the *ability* to support as much customization as the raw docking programs allow. With an eye towards servicing that first group of users, our goal is to minimize the overhead needed to setup a virtual screen.\n",
+    "\n",
+    "The following cell shows an example of setting up a screening protocol against the D4 dopamine receptor 5WIU using AutoDock Vina using the docking box centered at the given coordinates with the specified x-, y-, and z-radii. Because AutoDock Vina can leverage multiple cores during a docking run, we additionally specify that each process will be allotted `6` cores."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyscreener as ps\n",
+    "\n",
+    "md = ps.build_metadata(\"vina\")\n",
+    "vs = ps.virtual_screen(\n",
+    "    \"vina\",\n",
+    "    receptors=[\"integration-tests/inputs/5WIU.pdb\"], \n",
+    "    center=(-18.2, 14.4, -16.1),\n",
+    "    size=(15.4, 13.9, 14.5),\n",
+    "    metadata_template=md,\n",
+    "    ncpu=6\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To actually subject compounds to our virtual screening protocol, we simply `__call__()` our `VirtualScreen` on the SMILES string(s) of our compound(s) of interest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scores = vs(\"c1ccccc1\")\n",
+    "scores"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that it's also possible to pass in multiple SMILES strings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scores = vs(\"c1ccccc1\", \"O=C(Cc1ccccc1)NC1C(=O)N2C1SC(C2C(=O)O)(C)C\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also support directly passing in a `List` of SMILES strings if you want to evaluate batches of compounds at a time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "smis = [\n",
+    "    \"c1ccccc1\",\n",
+    "   \"O=C(Cc1ccccc1)NC1C(=O)N2C1SC(C2C(=O)O)(C)C\",\n",
+    "   \"C=CCN1CCC23C4C(=O)CCC2(C1CC5=C3C(=C(C=C5)O)O4)O\"\n",
+    "]\n",
+    "scores = vs(smis)\n",
+    "scores"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As mentioned above, we can customize the parameters of our virtual screen, such as the exhaustiveness. Most flags for AutoDock Vina are supported in this manner, simply pass in a dictionary to the `build_metadata()` function using the flag name as the key and the desired value\n",
+    "\n",
+    "With a higher exhaustiveness, individual docking runs will take longer (time scales roughly linearly with exhaustiveness,) but our results should be more repeatable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "md = ps.build_metadata(\"vina\", dict(exhaustivness=32))\n",
+    "vs = ps.virtual_screen(\n",
+    "    \"vina\",\n",
+    "    receptors=[\"integration-tests/inputs/5WIU.pdb\"], \n",
+    "    center=(-18.2, 14.4, -16.1),\n",
+    "    size=(15.4, 13.9, 14.5),\n",
+    "    metadata_template=md,\n",
+    "    ncpu=6\n",
+    ")\n",
+    "scores = vs(smis)\n",
+    "scores"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`pyscreener` also supports other programs in the AutoDock Vina family: QVina, Smina, and PSOVina. Simply pass in the desired program as the value to the `software` key in the `metadata` dictionary, like the cell below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "md = ps.build_metadata(\"vina\", dict(software=\"qvina\"))\n",
+    "vs = ps.virtual_screen(\n",
+    "    \"vina\",\n",
+    "    receptors=[\"integration-tests/inputs/5WIU.pdb\"], \n",
+    "    center=(-18.2, 14.4, -16.1),\n",
+    "    size=(15.4, 13.9, 14.5),\n",
+    "    metadata_template=md,\n",
+    "    ncpu=6\n",
+    ")\n",
+    "scores = vs(smis)\n",
+    "scores"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lastly, we also support DOCKing in `pyscreener`. Pass in `\"dock\"` for the `screen_type` argument to `build_metadata()` to accomplish this. *Note:* DOCK6 has a plethora of options with which to customize a DOCKing preparation **and** simulation. Some of these values are not supported at this time, but will be added in a future release of `pyscreener`!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metadata = ps.build_metadata(\"dock\")\n",
+    "vs = ps.virtual_screen(\n",
+    "    \"vina\",\n",
+    "    receptors=[\"integration-tests/inputs/5WIU.pdb\"], \n",
+    "    center=(-18.2, 14.4, -16.1),\n",
+    "    size=(15.4, 13.9, 14.5),\n",
+    "    metadata_template=md,\n",
+    "    ncpu=6\n",
+    ")\n",
+    "scores = vs(smis)\n",
+    "scores"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Distributing a Virtual Screen\n",
+    "\n",
+    "Sometimes you might want to screen a *large* number of compounds at once and will have access to the resources over which to distribute these docking runs. `pyscreener` offers first class support for task distribution using `ray` in the backend. To change your code from a local to distributed setup, simply connect to the proper `ray` cluster before running your virtual screen, like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ray\n",
+    "\n",
+    "ray.init(address=None, _redis_password=None)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/run_ps_vina.sh
+++ b/examples/run_ps_vina.sh
@@ -1,0 +1,1 @@
+pyscreener --config integration-tests/configs/test_vina.ini --ncpu 6

--- a/examples/run_pyscreener_distributed_example.batch
+++ b/examples/run_pyscreener_distributed_example.batch
@@ -45,4 +45,4 @@ done
 sleep 30
 ###############################################################################
 
-python run.py --config integration-tests/configs/test_vina.ini --ncpu $SLURM_CPUS_PER_TASK
+pyscreener --config integration-tests/configs/test_vina.ini --ncpu $SLURM_CPUS_PER_TASK


### PR DESCRIPTION
## Description
This PR adds a new `examples` folder, containing a notebook of how to use `pyscreener` and two additional scripts that show usage when run in batch.

## Current status
There are no examples, and this PR adds them

## Relevant issues
#23

## checklist
- [x] (if appropriate) unit tests added: `pytest`

## Status
- [x] Ready to go