### PR TITLE
fix some deprecated arguments

### DIFF
--- a/pyscreener/args.py
+++ b/pyscreener/args.py
@@ -36,7 +36,7 @@ def add_general_args(parser: ArgumentParser):
     parser.add_argument(
         "--smoke-test",
         action="store_true",
-        help="whether to perform a smoke test by checking if the environment is set up properly",
+        help="perform a smoke test by checking if the environment is set up properly",
     )
     parser.add_argument(
         "-o",
@@ -173,9 +173,6 @@ def add_screen_args(parser: ArgumentParser):
         default="best",
         choices=set(r.name for r in Reduction),
         help="The method used to calculate the overall score from an ensemble of docking runs",
-    )
-    parser.add_argument(
-        "--repeats", default=1, type=int, help="the number of times to repeat each docking run"
     )
     parser.add_argument(
         "-k",

--- a/pyscreener/main.py
+++ b/pyscreener/main.py
@@ -75,7 +75,6 @@ def main():
         args.output_dir,
         args.reduction,
         args.receptor_reduction,
-        args.repeats,
         args.k,
         args.verbose,
     )
@@ -110,7 +109,7 @@ def main():
             args.hist_mode, S, virtual_screen.path, "score_distribution.png"
         )
 
-    results = virtual_screen.all_results()
+    results = virtual_screen.results()
     if not args.no_sort:
         results = sorted(results, key=lambda r: r.score if r.score is not None else float("inf"))
     smis_scores = [(r.smiles, r.score) for r in results]


### PR DESCRIPTION
## Summary
- Fixes #41
- Fixes #42

## Description
removes some deprecated arguments and fixes calling the old `all_results()` method instead of the new `results()`
