### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN pip install --no-input --no-cache-dir pyscreener
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS vina-install
+FROM base AS base-vina
 
 RUN mkdir vina_download \
     && cd vina_download \
@@ -81,13 +81,13 @@ RUN mkdir vina_download \
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM vina-install as vina-prod
+FROM base-vina as vina-prod
 
 RUN pip install --no-input --no-cache-dir pyscreener
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM vina-install as vina-dev
+FROM base-vina as vina-dev
 
 WORKDIR /pyscreener_install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,17 @@ RUN mkdir vina_download \
     && mv autodock_vina_1_1_2_linux_x86/bin/* ../bin/ \
     && cd ..\
     && rm -rf vina_download
+
+# need these for psovina install / build
+RUN apt-get install make g++ libboost-all-dev -y
+
+RUN mkdir psovina_download \
+    && cd psovina_download \
+    && wget -O psovina-2.0.tar.gz https://sourceforge.net/projects/psovina/files/psovina-2.0.tar.gz/download \
+    && tar -xzvf psovina-2.0.tar.gz \
+    && cd psovina-2.0/build/linux/release/ \
+    && make \
+    && mv psovina* ../../../../../bin/ \
+    && cd ../../../../../ \
+    && rm -rf psovina_download
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,6 @@ FROM continuumio/miniconda3 AS base
 RUN apt-get update \
     && apt-get install make g++ libboost-all-dev xutils-dev -y
 
-RUN wget -O ADFRsuite.tar.gz https://ccsb.scripps.edu/adfr/download/1038/ \
-    && tar -xzvf ADFRsuite.tar.gz \
-    && cd ADFRsuite_* \
-    && echo "Y" | ./install.sh -d . -c 0 \
-    && cd ..\
-    && rm ADFRsuite.tar.gz
-
-ENV PATH="${PATH}:/ADFRsuite_x86_64Linux_1.0/bin:"
-
 COPY environment.yml .
 
 RUN conda env create --file environment.yml \
@@ -24,7 +15,20 @@ RUN pip install --no-input --no-cache-dir pyscreener
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS vina
+FROM base AS vina-base
+
+RUN wget -O ADFRsuite.tar.gz https://ccsb.scripps.edu/adfr/download/1038/ \
+    && tar -xzvf ADFRsuite.tar.gz \
+    && cd ADFRsuite_* \
+    && echo "Y" | ./install.sh -d . -c 0 \
+    && cd ..\
+    && rm ADFRsuite.tar.gz
+
+ENV PATH="${PATH}:/ADFRsuite_x86_64Linux_1.0/bin:"
+
+
+# ------------------------------------------------------------------------------------------------------------
+FROM vina-base AS vina
 
 RUN mkdir vina_download \
     && cd vina_download \
@@ -36,7 +40,7 @@ RUN mkdir vina_download \
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS psovina
+FROM vina-base AS psovina
 
 RUN mkdir psovina_download \
     && cd psovina_download \
@@ -50,7 +54,7 @@ RUN mkdir psovina_download \
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS smina
+FROM vina-base AS smina
 
 RUN mkdir smina_download \
     && cd smina_download \  
@@ -62,7 +66,7 @@ RUN mkdir smina_download \
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS qvina
+FROM vina-base AS qvina
 
 SHELL ["/bin/bash", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,30 @@
 # ------------------------------------------------------------------------------------------------------------
-FROM continuumio/miniconda3 AS base
+FROM mambaorg/micromamba:latest AS base
+
+USER root
 
 RUN apt-get update \
-    && apt-get install make g++ libboost-all-dev xutils-dev -y
+    && apt-get install wget make g++ libboost-all-dev xutils-dev libxss1 xscreensaver xscreensaver-gl-extra xvfb -y
 
 COPY environment.yml .
 
-RUN conda env create --file environment.yml \
-    && conda clean -afy
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
-SHELL ["conda", "run", "-n", "pyscreener", "/bin/bash", "-c"]
-
-RUN pip install --no-input --no-cache-dir pyscreener
-
-
-# ------------------------------------------------------------------------------------------------------------
-FROM base as base-dock6
-
-RUN apt-get install libxss1 xscreensaver xscreensaver-gl-extra xvfb -y \
-    && mkdir dock6_utils
-
-RUN cd dock6_utils \
-    && mkdir sphgen_cpp_download && cd sphgen_cpp_download \
-    && wget http://dock.compbio.ucsf.edu/Contributed_Code/code/sphgen_cpp.1.2.tar.gz \
-    && tar -xzvf sphgen_cpp.1.2.tar.gz \
-    && cd sphgen_cpp.1.2 \
-    && make \
-    && mv sphgen_cpp ../../ \
-    && cd ../../ && rm -rf sphgen_cpp_download
-
-RUN cd dock6_utils \
-    && wget -O chimera-installer.bin "https://www.cgl.ucsf.edu/chimera/cgi-bin/secure/chimera-get.py?ident=OHeQer2WSaxn%2FepyqXlK%2BP9gulBVQ9j%2B1xtw0AnmnvIv&file=linux_x86_64%2Fchimera-1.16-linux_x86_64.bin&choice=Notified" \
-    && chmod +x chimera-installer.bin
+RUN micromamba install -y -n base -f environment.yml \
+    && pip install pyscreener \
+    && micromamba clean --all --yes
 
 
 # ------------------------------------------------------------------------------------------------------------
 FROM base AS base-vina
 
 RUN wget -O ADFRsuite.tar.gz https://ccsb.scripps.edu/adfr/download/1038/ \
+    && mv ADFRsuite.tar.gz ../ && cd .. \
     && tar -xzvf ADFRsuite.tar.gz \
     && cd ADFRsuite_* \
     && echo "Y" | ./install.sh -d . -c 0 \
-    && cd ..\
-    && rm ADFRsuite.tar.gz
+    && cd .. \
+    && rm -rf ADFRsuite.tar.gz
 
 ENV PATH="${PATH}:/ADFRsuite_x86_64Linux_1.0/bin:"
 
@@ -50,39 +32,27 @@ ENV PATH="${PATH}:/ADFRsuite_x86_64Linux_1.0/bin:"
 # ------------------------------------------------------------------------------------------------------------
 FROM base-vina AS vina
 
-RUN mkdir vina_download \
-    && cd vina_download \
-    && wget https://vina.scripps.edu/wp-content/uploads/sites/55/2020/12/autodock_vina_1_1_2_linux_x86.tgz \
+RUN wget https://vina.scripps.edu/wp-content/uploads/sites/55/2020/12/autodock_vina_1_1_2_linux_x86.tgz \
     && tar -xzvf autodock_vina_1_1_2_linux_x86.tgz \
-    && mv autodock_vina_1_1_2_linux_x86/bin/* ../bin/ \
-    && cd ..\
-    && rm -rf vina_download
+    && mv autodock_vina_1_1_2_linux_x86/bin/* ../bin/
 
 
 # ------------------------------------------------------------------------------------------------------------
 FROM base-vina AS psovina
 
-RUN mkdir psovina_download \
-    && cd psovina_download \
-    && wget -O psovina-2.0.tar.gz https://sourceforge.net/projects/psovina/files/psovina-2.0.tar.gz/download \
+RUN wget -O psovina-2.0.tar.gz https://sourceforge.net/projects/psovina/files/psovina-2.0.tar.gz/download \
     && tar -xzvf psovina-2.0.tar.gz \
     && cd psovina-2.0/build/linux/release/ \
     && make \
-    && mv psovina* ../../../../../bin/ \
-    && cd ../../../../../ \
-    && rm -rf psovina_download
+    && mv psovina* ../../../../../bin/
 
 
 # ------------------------------------------------------------------------------------------------------------
 FROM base-vina AS smina
 
-RUN mkdir smina_download \
-    && cd smina_download \  
-    && wget -O smina https://sourceforge.net/projects/smina/files/smina.static/download \
+RUN wget -O smina https://sourceforge.net/projects/smina/files/smina.static/download \
     && chmod +x smina \
-    && mv smina ../bin/ \
-    && cd ../ \ 
-    && rm -rf smina_download
+    && mv smina ../bin/
 
 
 # ------------------------------------------------------------------------------------------------------------
@@ -90,12 +60,13 @@ FROM base-vina AS qvina
 
 SHELL ["/bin/bash", "-c"]
 
-RUN git clone -b qvina2_1buffer --single-branch https://github.com/QVina/qvina.git \
+RUN apt-get install git -y \
+    && git clone -b qvina2_1buffer --single-branch https://github.com/QVina/qvina.git \
     && cd qvina \
     && BOOST_LOC=$(whereis boost) && BOOST_PATH=${BOOST_LOC:7:19} && BOOST_VERSION=$(grep "#define BOOST_LIB_VERSION" ../../usr/include/boost/version.hpp | grep -o '".*"' | sed 's/"//g') \
     && sed -i "1s|.*|BASE=$BOOST_PATH|" Makefile && sed -i "2s|.*|BASE=$BOOST_VERSION|" Makefile \
     && make \
-    && mv qvina02 ../bin/qvina \
+    && mv qvina02 ../../bin/qvina \
     && cd ../ && rm -rf qvina
     # rename qvina02 to qvina otherwise pyscreener raises an error with executable name
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,3 +72,22 @@ RUN apt-get install git -y \
 
 
 # ------------------------------------------------------------------------------------------------------------
+FROM base as base-dock6
+
+RUN mkdir ../dock6_utils
+
+RUN cd ../dock6_utils \
+    && mkdir sphgen_cpp_download && cd sphgen_cpp_download \
+    && wget http://dock.compbio.ucsf.edu/Contributed_Code/code/sphgen_cpp.1.2.tar.gz \
+    && tar -xzvf sphgen_cpp.1.2.tar.gz \
+    && cd sphgen_cpp.1.2 \
+    && make \
+    && mv sphgen_cpp ../../ \
+    && cd ../../ && rm -rf sphgen_cpp_download
+
+RUN cd ../dock6_utils \
+    && wget -O chimera-installer.bin "https://www.cgl.ucsf.edu/chimera/cgi-bin/secure/chimera-get.py?ident=OHeQer2WSaxn%2FepyqXlK%2BP9gulBVQ9j%2B1xtw0AnmnvIv&file=linux_x86_64%2Fchimera-1.16-linux_x86_64.bin&choice=Notified" \
+    && chmod +x chimera-installer.bin
+
+
+# ------------------------------------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,11 @@ RUN mkdir psovina_download \
     && cd ../../../../../ \
     && rm -rf psovina_download
 
+# smina
+RUN mkdir smina_download \
+    && cd smina_download \  
+    && wget -O smina https://sourceforge.net/projects/smina/files/smina.static/download \
+    && chmod +x smina \
+    && mv smina ../bin/ \
+    && cd ../ \ 
+    && rm -rf smina_download

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,27 @@ RUN pip install --no-input --no-cache-dir pyscreener
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS vina-base
+FROM base as base-dock6
+
+RUN apt-get install libxss1 xscreensaver xscreensaver-gl-extra xvfb -y \
+    && mkdir dock6_utils
+
+RUN cd dock6_utils \
+    && mkdir sphgen_cpp_download && cd sphgen_cpp_download \
+    && wget http://dock.compbio.ucsf.edu/Contributed_Code/code/sphgen_cpp.1.2.tar.gz \
+    && tar -xzvf sphgen_cpp.1.2.tar.gz \
+    && cd sphgen_cpp.1.2 \
+    && make \
+    && mv sphgen_cpp ../../ \
+    && cd ../../ && rm -rf sphgen_cpp_download
+
+RUN cd dock6_utils \
+    && wget -O chimera-installer.bin "https://www.cgl.ucsf.edu/chimera/cgi-bin/secure/chimera-get.py?ident=OHeQer2WSaxn%2FepyqXlK%2BP9gulBVQ9j%2B1xtw0AnmnvIv&file=linux_x86_64%2Fchimera-1.16-linux_x86_64.bin&choice=Notified" \
+    && chmod +x chimera-installer.bin
+
+
+# ------------------------------------------------------------------------------------------------------------
+FROM base AS base-vina
 
 RUN wget -O ADFRsuite.tar.gz https://ccsb.scripps.edu/adfr/download/1038/ \
     && tar -xzvf ADFRsuite.tar.gz \
@@ -28,7 +48,7 @@ ENV PATH="${PATH}:/ADFRsuite_x86_64Linux_1.0/bin:"
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM vina-base AS vina
+FROM base-vina AS vina
 
 RUN mkdir vina_download \
     && cd vina_download \
@@ -40,7 +60,7 @@ RUN mkdir vina_download \
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM vina-base AS psovina
+FROM base-vina AS psovina
 
 RUN mkdir psovina_download \
     && cd psovina_download \
@@ -54,7 +74,7 @@ RUN mkdir psovina_download \
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM vina-base AS smina
+FROM base-vina AS smina
 
 RUN mkdir smina_download \
     && cd smina_download \  
@@ -66,7 +86,7 @@ RUN mkdir smina_download \
 
 
 # ------------------------------------------------------------------------------------------------------------
-FROM vina-base AS qvina
+FROM base-vina AS qvina
 
 SHELL ["/bin/bash", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,23 @@ RUN conda env create --file environment.yml \
 
 SHELL ["conda", "run", "-n", "pyscreener", "/bin/bash", "-c"]
 
+RUN pip install --no-input --no-cache-dir pyscreener
+
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS psovina-prod
+FROM base AS vina
+
+RUN mkdir vina_download \
+    && cd vina_download \
+    && wget https://vina.scripps.edu/wp-content/uploads/sites/55/2020/12/autodock_vina_1_1_2_linux_x86.tgz \
+    && tar -xzvf autodock_vina_1_1_2_linux_x86.tgz \
+    && mv autodock_vina_1_1_2_linux_x86/bin/* ../bin/ \
+    && cd ..\
+    && rm -rf vina_download
+
+
+# ------------------------------------------------------------------------------------------------------------
+FROM base AS psovina
 
 RUN mkdir psovina_download \
     && cd psovina_download \
@@ -34,11 +48,9 @@ RUN mkdir psovina_download \
     && cd ../../../../../ \
     && rm -rf psovina_download
 
-RUN pip install --no-input --no-cache-dir pyscreener
-
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS smina-prod
+FROM base AS smina
 
 RUN mkdir smina_download \
     && cd smina_download \  
@@ -48,11 +60,9 @@ RUN mkdir smina_download \
     && cd ../ \ 
     && rm -rf smina_download
 
-RUN pip install --no-input --no-cache-dir pyscreener
-
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS qvina-prod
+FROM base AS qvina
 
 SHELL ["/bin/bash", "-c"]
 
@@ -65,32 +75,5 @@ RUN git clone -b qvina2_1buffer --single-branch https://github.com/QVina/qvina.g
     && cd ../ && rm -rf qvina
     # rename qvina02 to qvina otherwise pyscreener raises an error with executable name
 
-RUN pip install --no-input --no-cache-dir pyscreener
-
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS base-vina
-
-RUN mkdir vina_download \
-    && cd vina_download \
-    && wget https://vina.scripps.edu/wp-content/uploads/sites/55/2020/12/autodock_vina_1_1_2_linux_x86.tgz \
-    && tar -xzvf autodock_vina_1_1_2_linux_x86.tgz \
-    && mv autodock_vina_1_1_2_linux_x86/bin/* ../bin/ \
-    && cd ..\
-    && rm -rf vina_download
-
-
-# ------------------------------------------------------------------------------------------------------------
-FROM base-vina as vina-prod
-
-RUN pip install --no-input --no-cache-dir pyscreener
-
-
-# ------------------------------------------------------------------------------------------------------------
-FROM base-vina as vina-dev
-
-WORKDIR /pyscreener_install
-
-COPY . .
-
-RUN pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM continuumio/miniconda3
+
+RUN apt-get update \
+    && apt-get install -y
+
+COPY environment.yml .
+
+RUN conda env create --file environment.yml \
+    && conda clean -afy
+
+SHELL ["conda", "run", "-n", "pyscreener", "/bin/bash", "-c"]
+
+RUN pip install --no-input --no-cache-dir pyscreener
+
+# install vina here
+RUN mkdir vina_download \
+    && cd vina_download \
+    && wget https://vina.scripps.edu/wp-content/uploads/sites/55/2020/12/autodock_vina_1_1_2_linux_x86.tgz \
+    && tar -xzvf autodock_vina_1_1_2_linux_x86.tgz \
+    && mv autodock_vina_1_1_2_linux_x86/bin/* ../bin/ \
+    && cd ..\
+    && rm -rf vina_download

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,12 @@ RUN mkdir vina_download \
 
 
 # ------------------------------------------------------------------------------------------------------------
+FROM vina-install as vina-prod
+
+RUN pip install --no-input --no-cache-dir pyscreener
+
+
+# ------------------------------------------------------------------------------------------------------------
 FROM vina-install as vina-dev
 
 WORKDIR /pyscreener_install
@@ -88,12 +94,3 @@ WORKDIR /pyscreener_install
 COPY . .
 
 RUN pip install .
-
-
-# ------------------------------------------------------------------------------------------------------------
-FROM vina-install as vina-prod
-
-RUN pip install --no-input --no-cache-dir pyscreener
-
-
-# ------------------------------------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,15 @@ FROM continuumio/miniconda3 AS base
 RUN apt-get update \
     && apt-get install make g++ libboost-all-dev xutils-dev -y
 
+RUN wget -O ADFRsuite.tar.gz https://ccsb.scripps.edu/adfr/download/1038/ \
+    && tar -xzvf ADFRsuite.tar.gz \
+    && cd ADFRsuite_* \
+    && echo "Y" | ./install.sh -d . -c 0 \
+    && cd ..\
+    && rm ADFRsuite.tar.gz
+
+ENV PATH="${PATH}:/ADFRsuite_x86_64Linux_1.0/bin:"
+
 COPY environment.yml .
 
 RUN conda env create --file environment.yml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,3 +42,14 @@ RUN mkdir smina_download \
     && mv smina ../bin/ \
     && cd ../ \ 
     && rm -rf smina_download
+
+
+# qvina
+RUN apt-get install xutils-dev -y \
+    && git clone -b qvina2_1buffer --single-branch https://github.com/QVina/qvina.git \
+    && cd qvina \
+    && BOOST_LOC=$(whereis boost) && BOOST_PATH=${BOOST_LOC:7:19} && BOOST_VERSION=$(grep "#define BOOST_LIB_VERSION" ../../usr/include/boost/version.hpp | grep -o '".*"' | sed 's/"//g') \
+    && sed -i "1s|.*|BASE=$BOOST_PATH|" Makefile && sed -i "2s|.*|BASE=$BOOST_VERSION|" Makefile \
+    && make \
+    && mv qvina02 ../bin/ \
+    && cd ../ && rm -rf qvina

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,23 +20,9 @@ RUN conda env create --file environment.yml \
 
 SHELL ["conda", "run", "-n", "pyscreener", "/bin/bash", "-c"]
 
-RUN pip install --no-input --no-cache-dir pyscreener
-
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS vina
-
-RUN mkdir vina_download \
-    && cd vina_download \
-    && wget https://vina.scripps.edu/wp-content/uploads/sites/55/2020/12/autodock_vina_1_1_2_linux_x86.tgz \
-    && tar -xzvf autodock_vina_1_1_2_linux_x86.tgz \
-    && mv autodock_vina_1_1_2_linux_x86/bin/* ../bin/ \
-    && cd ..\
-    && rm -rf vina_download
-
-
-# ------------------------------------------------------------------------------------------------------------
-FROM base AS psovina
+FROM base AS psovina-prod
 
 RUN mkdir psovina_download \
     && cd psovina_download \
@@ -48,9 +34,11 @@ RUN mkdir psovina_download \
     && cd ../../../../../ \
     && rm -rf psovina_download
 
+RUN pip install --no-input --no-cache-dir pyscreener
+
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS smina
+FROM base AS smina-prod
 
 RUN mkdir smina_download \
     && cd smina_download \  
@@ -60,9 +48,11 @@ RUN mkdir smina_download \
     && cd ../ \ 
     && rm -rf smina_download
 
+RUN pip install --no-input --no-cache-dir pyscreener
+
 
 # ------------------------------------------------------------------------------------------------------------
-FROM base AS qvina
+FROM base AS qvina-prod
 
 SHELL ["/bin/bash", "-c"]
 
@@ -74,6 +64,36 @@ RUN git clone -b qvina2_1buffer --single-branch https://github.com/QVina/qvina.g
     && mv qvina02 ../bin/qvina \
     && cd ../ && rm -rf qvina
     # rename qvina02 to qvina otherwise pyscreener raises an error with executable name
+
+RUN pip install --no-input --no-cache-dir pyscreener
+
+
+# ------------------------------------------------------------------------------------------------------------
+FROM base AS vina-install
+
+RUN mkdir vina_download \
+    && cd vina_download \
+    && wget https://vina.scripps.edu/wp-content/uploads/sites/55/2020/12/autodock_vina_1_1_2_linux_x86.tgz \
+    && tar -xzvf autodock_vina_1_1_2_linux_x86.tgz \
+    && mv autodock_vina_1_1_2_linux_x86/bin/* ../bin/ \
+    && cd ..\
+    && rm -rf vina_download
+
+
+# ------------------------------------------------------------------------------------------------------------
+FROM vina-install as vina-dev
+
+WORKDIR /pyscreener_install
+
+COPY . .
+
+RUN pip install .
+
+
+# ------------------------------------------------------------------------------------------------------------
+FROM vina-install as vina-prod
+
+RUN pip install --no-input --no-cache-dir pyscreener
 
 
 # ------------------------------------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,6 @@ RUN apt-get install xutils-dev -y \
     && BOOST_LOC=$(whereis boost) && BOOST_PATH=${BOOST_LOC:7:19} && BOOST_VERSION=$(grep "#define BOOST_LIB_VERSION" ../../usr/include/boost/version.hpp | grep -o '".*"' | sed 's/"//g') \
     && sed -i "1s|.*|BASE=$BOOST_PATH|" Makefile && sed -i "2s|.*|BASE=$BOOST_VERSION|" Makefile \
     && make \
-    && mv qvina02 ../bin/ \
+    && mv qvina02 ../bin/qvina \
     && cd ../ && rm -rf qvina
+    # rename qvina02 to qvina otherwise pyscreener raises an error with executable name

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A compiled form of `sphgen_cpp` and the binary required for installation of `chi
 
 **Notes :** 
 1. Within the docker container, the environment `base` will be activated by default. This contains all the required python dependencies so there is no need to manually activate an environment once inside the container
-2. If installing using docker, then the below installation stages are not required with the exception of `DOCK6` however.
+2. If installing using docker, then the below installation stages are not required for the corresponding vina-type software. However, the DOCK6 directions must still be followed.
 
 ### General requirements
 - python >= 3.8

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ This repository contains the source of pyscreener, both a library and software f
 
 ## Installation
 
+### Docker
+The provided `Dockerfile` can be used to create pyscreener instances containing the required docking software and python dependencies / code. Any of the four vina docking softwares - `vina`, `qvina2`, `smina`, and `psovina` - can be specified for installation to the docker image. All python dependencies and the pyscreener library are installed to a conda environment named `pyscreener` which must be activated once the docker image starts. The commands for creating the docker images are:
+* `docker build -t pyscreener:base --target base .` : Creates a docker image containing all python dependencies and pyscreener library but no docking software (ADFR suite is present in this image however and is also present in all subsequent images)
+* `docker build -t pyscreener:vina --target vina .` : Creates an image from `pyscreener:base` with `vina` installed 
+* `docker build -t pyscreener:qvina --target qvina .` : Creates an image from `pyscreener:base` with `qvina` installed 
+* `docker build -t pyscreener:smina --target smina .` : Creates an image from `pyscreener:base` with `smina` installed 
+* `docker build -t pyscreener:psovina --target psovina .` : Creates an image from `pyscreener:base` with `psovina` installed 
+
+If docker is not installed already for your system then it can be installed from [the official docker website](https://docs.docker.com/get-docker/).
+
+Note : The above commands assume you are running them within the directory containing both `Dockerfile` and `environment.yml`
+
 ### General requirements
 - python >= 3.8
 - `numpy`, `openbabel`, `openmm`, `pdbfixer`, `ray`, `rdkit`, `scikit-learn`, `scipy`, and `tqdm`

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The below commands can be run in the directory containing the `Dockerfile` and `
 * `docker build -t pyscreener:psovina --target psovina .` : Creates an image from `pyscreener:base` with `psovina` installed 
 
 As `DOCK6` software requires a license, it is not possible to include its installation within the associated docker image.
-A compiled form of `sphgen_cpp` and the binary required for installation of `chimera` are both available within the `dock6_utils` directory of the associated dock6 imge:
+A compiled form of `sphgen_cpp` and the binary required for installation of `chimera` are both available within the `dock6_utils` directory of the associated dock6 image:
 * `docker build -t pyscreener:dock6 --target base-dock6 .` : Creates an image from `pyscreener:base` containing utility software needed for `DOCK6` to run once installed 
 
 Notes : 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ As `DOCK6` software requires a license, it is not possible to include its instal
 A compiled form of `sphgen_cpp` and the binary required for installation of `chimera` are both available within the `dock6_utils` directory of the associated dock6 imge:
 * `docker build -t pyscreener:dock6 --target base-dock6 .` : Creates an image from `pyscreener:base` containing utility software needed for `DOCK6` to run once installed 
 
-Note : If installing using docker, then the below installation stages are not required with the exception of `DOCK6` however.
+Notes : 
+1. Within the docker container, the environment `base` will e activated by default which contains all the required python dependencies so there is no need to manually activate an environment once inside the container
+2. If installing using docker, then the below installation stages are not required with the exception of `DOCK6` however.
 
 ### General requirements
 - python >= 3.8

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A compiled form of `sphgen_cpp` and the binary required for installation of `chi
 * `docker build -t pyscreener:dock6 --target base-dock6 .` : Creates an image from `pyscreener:base` containing utility software needed for `DOCK6` to run once installed 
 
 **Notes :** 
-1. Within the docker container, the environment `base` will e activated by default which contains all the required python dependencies so there is no need to manually activate an environment once inside the container
+1. Within the docker container, the environment `base` will be activated by default. This contains all the required python dependencies so there is no need to manually activate an environment once inside the container
 2. If installing using docker, then the below installation stages are not required with the exception of `DOCK6` however.
 
 ### General requirements

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ for more examples, check out the [examples](./examples/) folder!
 
 ## Testing
 
-1. `pip install pytest`
+1. `pip install pytest-cov`
 1. `pytest`
 
 ## Copyright

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ As `DOCK6` software requires a license, it is not possible to include its instal
 A compiled form of `sphgen_cpp` and the binary required for installation of `chimera` are both available within the `dock6_utils` directory of the associated dock6 imge:
 * `docker build -t pyscreener:dock6 --target base-dock6 .` : Creates an image from `pyscreener:base` containing utility software needed for `DOCK6` to run once installed 
 
-Note : If installing using docker, then the below installation stages are not required.
+Note : If installing using docker, then the below installation stages are not required with the exception of `DOCK6` however.
 
 ### General requirements
 - python >= 3.8

--- a/README.md
+++ b/README.md
@@ -23,16 +23,23 @@ This repository contains the source of pyscreener, both a library and software f
 ## Installation
 
 ### Docker
-The provided `Dockerfile` can be used to create pyscreener instances containing the required docking software and python dependencies / code. Any of the four vina docking softwares - `vina`, `qvina2`, `smina`, and `psovina` - can be specified for installation to the docker image. All python dependencies and the pyscreener library are installed to a conda environment named `pyscreener` which must be activated once the docker image starts. The commands for creating the docker images are:
-* `docker build -t pyscreener:base --target base .` : Creates a docker image containing all python dependencies and pyscreener library but no docking software (ADFR suite is present in this image however and is also present in all subsequent images)
+If docker is not installed already for your system then it can be installed from [the official docker website](https://docs.docker.com/get-docker/).
+
+The provided `Dockerfile` can be used to create pyscreener instances containing the required docking software and python dependencies / code. Any of the four vina docking softwares - `vina`, `qvina2`, `smina`, and `psovina` - can be specified for installation to the docker image. 
+All python dependencies and the pyscreener library are installed to a conda environment named `pyscreener` which must be activated once the docker image starts. 
+
+The below commands can be run in the directory containing the `Dockerfile` and `environment.yml` files to build the desired image:
+* `docker build -t pyscreener:base --target base .` : Creates a docker image containing all python dependencies and pyscreener library but no docking software 
 * `docker build -t pyscreener:vina --target vina .` : Creates an image from `pyscreener:base` with `vina` installed 
 * `docker build -t pyscreener:qvina --target qvina .` : Creates an image from `pyscreener:base` with `qvina` installed 
 * `docker build -t pyscreener:smina --target smina .` : Creates an image from `pyscreener:base` with `smina` installed 
 * `docker build -t pyscreener:psovina --target psovina .` : Creates an image from `pyscreener:base` with `psovina` installed 
 
-If docker is not installed already for your system then it can be installed from [the official docker website](https://docs.docker.com/get-docker/).
+As `DOCK6` software requires a license, it is not possible to include its installation within the associated docker image.
+A compiled form of `sphgen_cpp` and the binary required for installation of `chimera` are both available within the `dock6_utils` directory of the associated dock6 imge:
+* `docker build -t pyscreener:dock6 --target base-dock6 .` : Creates an image from `pyscreener:base` containing utility software needed for `DOCK6` to run once installed 
 
-Note : The above commands assume you are running them within the directory containing both `Dockerfile` and `environment.yml`
+Note : If installing using docker, then the below installation stages are not required.
 
 ### General requirements
 - python >= 3.8

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ As `DOCK6` software requires a license, it is not possible to include its instal
 A compiled form of `sphgen_cpp` and the binary required for installation of `chimera` are both available within the `dock6_utils` directory of the associated dock6 image:
 * `docker build -t pyscreener:dock6 --target base-dock6 .` : Creates an image from `pyscreener:base` containing utility software needed for `DOCK6` to run once installed 
 
-Notes : 
+**Notes :** 
 1. Within the docker container, the environment `base` will e activated by default which contains all the required python dependencies so there is no need to manually activate an environment once inside the container
 2. If installing using docker, then the below installation stages are not required with the exception of `DOCK6` however.
 

--- a/environment.yml
+++ b/environment.yml
@@ -21,4 +21,3 @@ dependencies:
     - scikit_learn
     - scipy
     - tqdm
-

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: pyscreener
 
 channels:
+  - hcc
   - conda-forge
   - defaults
 
@@ -11,6 +12,7 @@ dependencies:
   - openbabel
   - openmm
   - rdkit
+  - adfr-suite
   - pip:
     - colorama
     - configargparse

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: pyscreener
 
 channels:
-  - hcc
   - conda-forge
   - defaults
 
@@ -12,7 +11,6 @@ dependencies:
   - openbabel
   - openmm
   - rdkit
-  - adfr-suite
   - pip:
     - colorama
     - configargparse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "pyscreener/_version.py"
 
-[tool.pytest.ini_options]
-addopts = "--cov pyscreener"
-
 [tool.coverage.run]
 branch = true
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "pyscreener/_version.py"
 
+[tool.pytest.ini_options]
+addopts = "--cov pyscreener"
+
 [tool.coverage.run]
 branch = true
 omit = [


### PR DESCRIPTION
## Description
This PR adds a Dockerfile which allows for easy installation of all python dependencies, the pyscreener library, ADFR suite tools and choice of vina based docking software to a contained docker image. This allows for reproducible and straightforward installation / testing / usage of the pyscreener code. All pytest checks pass as well as `smoke-test` for all vina versions.

## Example / Current workflow
Creating a docker image containing the pyscreener library, its dependencies, ADFR suite tools and the vina docking software can be accomplished with `docker build -t pyscreener:vina --target vina .` however any of the vina base docking softwares can be specified instead.

## Bugfix / Desired workflow
n/a

## Questions
Installing `qvina` / `psovina` requires building from source which raises some pragma issues during compilation. If any light can be shed on solving these issues / clarifying if these issues then that would be invaluable feedback.

## Relevant issues
n/a

## checklist
No new tests added but all docker builds pass the associated python and docking smoke tests

## Status
Not 100% ready as seeking feedback on compilation of `qvina` and `psovina` docking tools from souce