### PR TITLE
Feat/ray bump

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,13 +10,13 @@ dependencies:
   - python=3.8
   - openbabel
   - openmm
-  - rdkit
   - pip:
     - colorama
     - configargparse
     - h5py
     - numpy
-    - ray
+    - ray[default]>=2.0
+    - rdkit
     - pandas
     - scikit_learn
     - scipy

--- a/pyscreener/docking/dock/runner.py
+++ b/pyscreener/docking/dock/runner.py
@@ -229,7 +229,8 @@ class DOCKRunner(DockingRunner):
         scores = DOCKRunner.parse_logfile(logfile)
         score = None if scores is None else reduce_scores(scores, sim.reduction, k=sim.k)
 
-        sim.result = Result(sim.smi, name, re.sub("[:,.]", "", ray.state.current_node_id()), score)
+        node_id = re.sub("[:,.]", "", ray.util.get_node_ip_address())
+        sim.result = Result(sim.smi, name, node_id, score)
 
         return scores
 

--- a/pyscreener/docking/vina/runner.py
+++ b/pyscreener/docking/vina/runner.py
@@ -213,7 +213,8 @@ class VinaRunner(DockingRunner):
         else:
             score = utils.reduce_scores(np.array(scores), sim.reduction, k=sim.k)
 
-        sim.result = Result(sim.smi, name, re.sub("[:,.]", "", ray.state.current_node_id()), score)
+        node_id = re.sub("[:,.]", "", ray.util.get_node_ip_address())
+        sim.result = Result(sim.smi, name, node_id, score)
 
         return scores
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
 	numpy
     pandas
     pdbfixer
-    ray[default]
+    ray[default]>=2.0
 	scipy
 	tqdm
 


### PR DESCRIPTION
## Description
This PR bumps the ray version from 1 to 2

## The problem
Ray v2 has deprecated the `ray.state` module, so the calculation of the `node_id` attribute of the `Result` objects raises a `DeprecationWarning` and will likely break in the future

## The fix
This PR adds specifications for the ray version in the packing config and switches out the following calls:
```
- ray.state.get_current_node_id()
+ ray.util.get_node_ip_address()
```

## Questions
I'm not actually certain these give the _same_ information, but it's not that important. They just need to give _some_ identifying information about the node on which the files are located for file collection at the end.

## Status
- [x] Ready to go