### PR TITLE
autobox config should not have center

### DIFF
--- a/integration-tests/configs/test_autobox.ini
+++ b/integration-tests/configs/test_autobox.ini
@@ -8,5 +8,4 @@ metadata = {"software": "qvina"}
 receptors = [integration-tests/inputs/5WIU.pdb]
 input-files = [integration-tests/inputs/ligands.csv]
 
-center = [-18, 13.5, -17]
 size = [14, 12, 15]


### PR DESCRIPTION
center values should come from `docked-ligand-file`

## Description
autobox config file contains `center` values which prevents autobox function to kick in.

## Example / Current workflow
current autobox contains center value thus minimum bounding box around the ligand is not calculated.

## Bugfix / Desired workflow
 After removing the `center` line, I get the message `Autoboxed ligand from...`  showing that `autobox()` function is called successfully.

## Questions


## Relevant issues


## checklist
- [ ] (if appropriate) unit tests added: `pytest`

## Status
- [ ] Ready to go